### PR TITLE
Publishing did:web documents based on wallet items

### DIFF
--- a/aries_cloudagent/admin/server.py
+++ b/aries_cloudagent/admin/server.py
@@ -273,6 +273,7 @@ class AdminServer(BaseAdminServer):
                     "/api/docs/swagger.json",
                     "/favicon.ico",
                     "/ws",  # ws handler checks authentication
+                    "/.well-known/did.json",
                 ]
                 or path.startswith("/static/swagger/")
             )

--- a/aries_cloudagent/didweb/base.py
+++ b/aries_cloudagent/didweb/base.py
@@ -1,0 +1,105 @@
+import logging
+
+from pydid import DID, DIDDocument, DIDDocumentBuilder
+
+from pydid.verification_method import (
+    Ed25519VerificationKey2018,
+    VerificationMethod,
+)
+
+from ..wallet.base import BaseWallet
+from ..core.profile import ProfileSession
+from .util import retrieve_did_document, save_did_document
+
+LOGGER = logging.getLogger(__name__)
+
+
+class DIDWeb:
+    """Class for managing a did:web DID document."""
+
+    def __init__(self, session: ProfileSession):
+        """
+        Initialize DIDWeb.
+
+        Args:
+            session: The current profile session
+        """
+        self._session = session
+
+    @property
+    def session(self) -> ProfileSession:
+        """
+        Accessor for the current profile session.
+
+        Returns:
+            The current profile session
+
+        """
+        return self._session
+
+    async def create_from_wallet(self, did: DID, extras=None) -> str:
+        """Add content from wallet to DID document."""
+        wallet = self.session.inject(BaseWallet, required=False)
+        public_did_obj = await wallet.get_public_did()
+        recipient_key = public_did_obj.verkey
+        endpoint = public_did_obj.metadata["endpoint"]
+        did_document = DIDDocument
+        builder = DIDDocumentBuilder(did)
+        vmethod = builder.verification_method.add(
+            Ed25519VerificationKey2018, ident="key-1", public_key_base58=recipient_key
+        )
+        builder.authentication.reference(vmethod.id)
+        builder.assertion_method.reference(vmethod.id)
+        if endpoint:
+            builder.service.add_didcomm(
+                service_endpoint=endpoint,
+                recipient_keys=[vmethod],
+                routing_keys=[],
+            )
+
+        if extras is not None:
+            if "verification_methods" in extras:
+                verification_methods = extras["verification_methods"]
+                for idx, verification_method in enumerate(verification_methods):
+                    did = verification_method["did"]
+                    did_info = await wallet.get_local_did(did)
+                    key_type = did_info.key_type
+                    suite = VerificationSuite(
+                        VerificationMethod[key_type.name].value, "publicKeyBase58"
+                    )
+                    vmethod = builder.verification_method.add(
+                        # +2 since there's already the key related to the public DID
+                        ident=f"key-{idx+2}",
+                        suite=suite,
+                        material=did_info.verkey,
+                    )
+                    if "verification_relationships" in verification_method:
+                        vrelations = verification_method["verification_relationships"]
+                        for vrelation in vrelations:
+                            getattr(builder, vrelation).reference(vmethod.id)
+
+            if "services" in extras:
+                # TODO: Implement adding custom services
+                None
+
+        did_document = builder.build()
+
+        await save_did_document(did_document, self._session)
+        self._did_document = did_document
+        return did_document.serialize()
+
+    async def create(self, did_document) -> str:
+        await save_did_document(None, self._session)
+        self._did_document = did_document
+        return did_document
+
+    async def delete(self):
+        await save_did_document(None, self._session)
+        return None
+
+    async def retrieve(self) -> str:
+        did_document = await retrieve_did_document(self._session)
+        if did_document:
+            return did_document.serialize()
+        else:
+            return None

--- a/aries_cloudagent/didweb/routes.py
+++ b/aries_cloudagent/didweb/routes.py
@@ -7,7 +7,6 @@ from aiohttp import web
 from aiohttp_apispec import (
     docs,
     match_info_schema,
-    # querystring_schema,
     request_schema,
     response_schema,
 )
@@ -15,6 +14,7 @@ from aiohttp_apispec import (
 from marshmallow import fields, validate
 from ..admin.request_context import AdminRequestContext
 from ..messaging.models.openapi import OpenAPISchema
+
 from pydid.common import DID_PATTERN
 from .base import DIDWeb
 
@@ -53,8 +53,8 @@ class DIDDocOptionsSchema(OpenAPISchema):
             did=fields.Str(description="did", required=False),
             verification_relationships=fields.List(
                 fields.Str(description="verification relationships", required=False),
-                description="List of verification relationships"
-            )
+                description="List of verification relationships",
+            ),
         ),
         required=False,
         description="List of verification methods",
@@ -62,7 +62,8 @@ class DIDDocOptionsSchema(OpenAPISchema):
 
     services = fields.List(
         fields.Dict(description="service block", required=False),
-        description="List of service blocks", required=False
+        description="List of service blocks",
+        required=False,
     )
 
 
@@ -97,14 +98,7 @@ async def did_document(request: web.BaseRequest):
     context: AdminRequestContext = request["context"]
     session = await context.session()
     did_web = DIDWeb(session)
-    # did_web = session.inject(DIDWeb)
     did_document = await did_web.retrieve()
-    # except DIDNotFound as err:
-    #     raise web.HTTPNotFound(reason=err.roll_up) from err
-    # except DIDMethodNotSupported as err:
-    #     raise web.HTTPNotImplemented(reason=err.roll_up) from err
-    # except ResolverError as err:
-    #     raise web.HTTPInternalServerError(reason=err.roll_up) from err
     return web.json_response(did_document)
 
 
@@ -118,12 +112,6 @@ async def read_did_document(request: web.BaseRequest):
     did_web = DIDWeb(session)
 
     did_document = await did_web.retrieve()
-    # except DIDNotFound as err:
-    #     raise web.HTTPNotFound(reason=err.roll_up) from err
-    # except DIDMethodNotSupported as err:
-    #     raise web.HTTPNotImplemented(reason=err.roll_up) from err
-    # except ResolverError as err:
-    #     raise web.HTTPInternalServerError(reason=err.roll_up) from err
     if not did_document:
         return web.HTTPNotFound()
     else:
@@ -138,14 +126,7 @@ async def create_did_document(request: web.BaseRequest):
     context: AdminRequestContext = request["context"]
     session = await context.session()
     did_web = DIDWeb(session)
-    # did_web = session.inject(DIDWeb)
     did_document = await did_web.create()
-    # except DIDNotFound as err:
-    #     raise web.HTTPNotFound(reason=err.roll_up) from err
-    # except DIDMethodNotSupported as err:
-    #     raise web.HTTPNotImplemented(reason=err.roll_up) from err
-    # except ResolverError as err:
-    #     raise web.HTTPInternalServerError(reason=err.roll_up) from err
     return web.json_response(did_document)
 
 
@@ -172,7 +153,9 @@ async def register(app: web.Application):
             web.get("/.well-known/did.json", did_document, allow_head=False),
             web.get("/didweb/read", read_did_document, allow_head=False),
             web.post("/didweb/create-raw", create_did_document),
-            web.post("/didweb/create-from-wallet/{did}", create_did_document_from_wallet)
+            web.post(
+                "/didweb/create-from-wallet/{did}", create_did_document_from_wallet
+            ),
         ]
     )
 
@@ -189,7 +172,7 @@ def post_process_routes(app: web.Application):
             "description": "did web interface.",
             "externalDocs": {
                 "description": "Specification",
-                "url": "https://w3c-ccg.github.io/did-method-web"
+                "url": "https://w3c-ccg.github.io/did-method-web",
             },
         }
     )

--- a/aries_cloudagent/didweb/routes.py
+++ b/aries_cloudagent/didweb/routes.py
@@ -1,0 +1,195 @@
+"""
+DID web admin routes and public endpoint.
+
+"""
+
+from aiohttp import web
+from aiohttp_apispec import (
+    docs,
+    match_info_schema,
+    # querystring_schema,
+    request_schema,
+    response_schema,
+)
+
+from marshmallow import fields, validate
+from ..admin.request_context import AdminRequestContext
+from ..messaging.models.openapi import OpenAPISchema
+from pydid.common import DID_PATTERN
+from .base import DIDWeb
+
+
+class W3cDIDDoc(validate.Regexp):
+    """Validate value against w3c DID document."""
+
+    EXAMPLE = "*"
+    PATTERN = DID_PATTERN
+
+    def __init__(self):
+        """Initializer."""
+
+        super().__init__(
+            W3cDIDDoc.PATTERN,
+            error="Value {input} is not a w3c decentralized identifier (DID) doc.",
+        )
+
+
+_W3cDIDDoc = {"validate": W3cDIDDoc(), "example": W3cDIDDoc.EXAMPLE}
+
+
+class DIDDocSchema(OpenAPISchema):
+    """Result schema for did document query."""
+
+    did_doc = fields.Str(
+        description="decentralize identifier(DID) document", required=True
+    )
+
+
+class DIDDocOptionsSchema(OpenAPISchema):
+    """Todo."""
+
+    verification_methods = fields.List(
+        fields.Dict(
+            did=fields.Str(description="did", required=False),
+            verification_relationships=fields.List(
+                fields.Str(description="verification relationships", required=False),
+                description="List of verification relationships"
+            )
+        ),
+        required=False,
+        description="List of verification methods",
+    )
+
+    services = fields.List(
+        fields.Dict(description="service block", required=False),
+        description="List of service blocks", required=False
+    )
+
+
+class W3cDID(validate.Regexp):
+    """Validate value against w3c DID."""
+
+    EXAMPLE = "did:ted:WgWxqztrNooG92RXvxSTWv"
+    PATTERN = DID_PATTERN
+
+    def __init__(self):
+        """Initializer."""
+
+        super().__init__(
+            W3cDID.PATTERN,
+            error="Value {input} is not a w3c decentralized identifier (DID)",
+        )
+
+
+_W3cDID = {"validate": W3cDID(), "example": W3cDID.EXAMPLE}
+
+
+class DIDMatchInfoSchema(OpenAPISchema):
+    """Path parameters and validators for request taking DID."""
+
+    did = fields.Str(
+        description="decentralize identifier(DID)", required=True, **_W3cDID
+    )
+
+
+async def did_document(request: web.BaseRequest):
+    """Retrieve a did document."""
+    context: AdminRequestContext = request["context"]
+    session = await context.session()
+    did_web = DIDWeb(session)
+    # did_web = session.inject(DIDWeb)
+    did_document = await did_web.retrieve()
+    # except DIDNotFound as err:
+    #     raise web.HTTPNotFound(reason=err.roll_up) from err
+    # except DIDMethodNotSupported as err:
+    #     raise web.HTTPNotImplemented(reason=err.roll_up) from err
+    # except ResolverError as err:
+    #     raise web.HTTPInternalServerError(reason=err.roll_up) from err
+    return web.json_response(did_document)
+
+
+@docs(tags=["didweb"], summary="Retrieve DID document")
+@response_schema(DIDDocSchema(), 200)
+async def read_did_document(request: web.BaseRequest):
+    """Retrieve a did document."""
+
+    context: AdminRequestContext = request["context"]
+    session = await context.session()
+    did_web = DIDWeb(session)
+
+    did_document = await did_web.retrieve()
+    # except DIDNotFound as err:
+    #     raise web.HTTPNotFound(reason=err.roll_up) from err
+    # except DIDMethodNotSupported as err:
+    #     raise web.HTTPNotImplemented(reason=err.roll_up) from err
+    # except ResolverError as err:
+    #     raise web.HTTPInternalServerError(reason=err.roll_up) from err
+    if not did_document:
+        return web.HTTPNotFound()
+    else:
+        return web.json_response(did_document)
+
+
+@docs(tags=["didweb"], summary="Create DID document")
+@request_schema(DIDDocSchema())
+@response_schema(DIDDocSchema(), 200, description="")
+async def create_did_document(request: web.BaseRequest):
+    """Create a did document."""
+    context: AdminRequestContext = request["context"]
+    session = await context.session()
+    did_web = DIDWeb(session)
+    # did_web = session.inject(DIDWeb)
+    did_document = await did_web.create()
+    # except DIDNotFound as err:
+    #     raise web.HTTPNotFound(reason=err.roll_up) from err
+    # except DIDMethodNotSupported as err:
+    #     raise web.HTTPNotImplemented(reason=err.roll_up) from err
+    # except ResolverError as err:
+    #     raise web.HTTPInternalServerError(reason=err.roll_up) from err
+    return web.json_response(did_document)
+
+
+@docs(tags=["didweb"], summary="Create DID document")
+@match_info_schema(DIDMatchInfoSchema())
+@request_schema(DIDDocOptionsSchema())
+@response_schema(DIDDocSchema(), 200, description="")
+async def create_did_document_from_wallet(request: web.BaseRequest):
+    """Create a did document."""
+    did = request.match_info["did"]
+    context: AdminRequestContext = request["context"]
+    session = await context.session()
+    did_web = DIDWeb(session)
+    options = await request.json()
+    did_document = await did_web.create_from_wallet(did, options)
+    return web.json_response(did_document)
+
+
+async def register(app: web.Application):
+    """Register routes."""
+
+    app.add_routes(
+        [
+            web.get("/.well-known/did.json", did_document, allow_head=False),
+            web.get("/didweb/read", read_did_document, allow_head=False),
+            web.post("/didweb/create-raw", create_did_document),
+            web.post("/didweb/create-from-wallet/{did}", create_did_document_from_wallet)
+        ]
+    )
+
+
+def post_process_routes(app: web.Application):
+    """Amend swagger API."""
+
+    # Add top-level tags description
+    if "tags" not in app._state["swagger_dict"]:
+        app._state["swagger_dict"]["tags"] = []
+    app._state["swagger_dict"]["tags"].append(
+        {
+            "name": "didweb",
+            "description": "did web interface.",
+            "externalDocs": {
+                "description": "Specification",
+                "url": "https://w3c-ccg.github.io/did-method-web"
+            },
+        }
+    )

--- a/aries_cloudagent/didweb/util.py
+++ b/aries_cloudagent/didweb/util.py
@@ -1,0 +1,42 @@
+from pydid import DIDDocument
+from enum import Enum
+from ..core.profile import ProfileSession
+from ..storage.base import (
+    BaseStorage,
+    StorageRecord,
+    StorageNotFoundError,
+)
+
+RECORD_TYPE_DID_DOC = "did_doc"
+
+
+async def retrieve_did_document(session: ProfileSession) -> DIDDocument:
+    """Retrieve DID document."""
+    storage = session.inject(BaseStorage)
+    try:
+        record = await storage.find_record(RECORD_TYPE_DID_DOC, {"did": "did:web"})
+    except StorageNotFoundError:
+        record = None
+    return DIDDocument.from_json(record.value) if record else None
+
+
+async def save_did_document(did_document: DIDDocument, session: ProfileSession):
+    """Save a DID document"""
+    storage = session.inject(BaseStorage)
+    try:
+        record = await storage.find_record(RECORD_TYPE_DID_DOC, {"did": "did:web"})
+    except StorageNotFoundError:
+        if did_document:
+            record = StorageRecord(
+                type=RECORD_TYPE_DID_DOC,
+                value=did_document.to_json(),
+                tags={"did": "did:web"},
+            )
+            await storage.add_record(record)
+    else:
+        if did_document:
+            await storage.update_record(
+                record, did_document.to_json(), {"did": "did:web"}
+            )
+        else:
+            await storage.delete_record(record)

--- a/aries_cloudagent/didweb/util.py
+++ b/aries_cloudagent/didweb/util.py
@@ -1,4 +1,9 @@
 from pydid import DIDDocument
+from pydid.verification_method import (
+    Bls1238G2Key2020,
+    Ed25519VerificationKey2018,
+)
+
 from enum import Enum
 from ..core.profile import ProfileSession
 from ..storage.base import (
@@ -8,6 +13,12 @@ from ..storage.base import (
 )
 
 RECORD_TYPE_DID_DOC = "did_doc"
+
+
+class VerificationMethod(Enum):
+
+    BLS12381G2 = Bls1238G2Key2020
+    ED25519 = Ed25519VerificationKey2018
 
 
 async def retrieve_did_document(session: ProfileSession) -> DIDDocument:


### PR DESCRIPTION
Plugin that allows to serve a did:web DID document based on keys in your wallet.

Rebased on main and will supersede https://github.com/hyperledger/aries-cloudagent-python/pull/1143

## Status

Working

## ToDo

- [ ] Create keys on the fly
- [ ] Use startup parameter
- [ ] Clean up routes
- [ ] Add tests
- [ ] More detailed Open API models  

## How to use 

Start ACA-Py with the plugin an with `--read-only-ledger`

Example:
```
PORTS="8000:8000 11000:11000" ./scripts/run_docker start \                                                                                                                                                     
-l Alice  \
-it http 0.0.0.0 8000 \
-ot http \
--admin 0.0.0.0 11000 \
--admin-insecure-mode \
--genesis-url https://indy-test.bosch-digital.de/genesis \
--seed {YOUR_SEED} \
--endpoint http://localhost:8000 \
--log-level 'Debug' \
--auto-provision \
--wallet-type indy \
--wallet-name Alice1 \
--wallet-key secret --public-invites \
--plugin 'aries_cloudagent.didweb' \
--read-only-ledger
```

### Serve did doc with just your public key based on the seed

```
POST:  /didweb​/create-from-wallet​/{did}

{
}
```

### Serve did doc with an additional wallet key and service

Create a local did, e.g. `did:key`
```
{
"verification_methods":[{
"did":"did:key:zUC7GcVEM3moH9aEp7QY8upYbWUGxFzfx3ci5wLjkT5EWXUaxbi3V3dgyK2H3HvGjHb2SKZHtMvbKcFBwszdUBcVRr5r3iWXqvK5SFw4qir6H9Bhno6cBNSBKxQ6y1hPLUNZBVv", 
"verification_relationships": ["assertion_method"]
}],
"services": [{
"type": "Profile", 
"service_endpoint": "https://myprofile.com"}]
}
```

