### PR TITLE
Fix: Alternate approach - update existing records using upgrade command

### DIFF
--- a/aries_cloudagent/protocols/present_proof/dif/pres_proposal_schema.py
+++ b/aries_cloudagent/protocols/present_proof/dif/pres_proposal_schema.py
@@ -3,7 +3,7 @@ from marshmallow import fields
 
 from ....messaging.models.openapi import OpenAPISchema
 
-from .pres_exch import InputDescriptorsSchema
+from .pres_exch import InputDescriptorsSchema, DIFOptionsSchema
 
 
 class DIFProofProposalSchema(OpenAPISchema):
@@ -14,5 +14,9 @@ class DIFProofProposalSchema(OpenAPISchema):
             InputDescriptorsSchema(),
             required=True,
         ),
+        required=False,
+    )
+    options = fields.Nested(
+        DIFOptionsSchema(),
         required=False,
     )

--- a/aries_cloudagent/protocols/present_proof/v1_0/handlers/presentation_handler.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/handlers/presentation_handler.py
@@ -49,7 +49,7 @@ class PresentationHandler(BaseHandler):
         )
 
         # Automatically move to next state if flag is set
-        if context.settings.get("debug.auto_verify_presentation"):
+        if presentation_exchange_record and presentation_exchange_record.auto_verify:
             try:
                 await presentation_manager.verify_presentation(
                     presentation_exchange_record

--- a/aries_cloudagent/protocols/present_proof/v1_0/manager.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/manager.py
@@ -165,7 +165,10 @@ class PresentationManager:
         return presentation_exchange_record, presentation_request_message
 
     async def create_exchange_for_request(
-        self, connection_id: str, presentation_request_message: PresentationRequest
+        self,
+        connection_id: str,
+        presentation_request_message: PresentationRequest,
+        auto_verify: bool = None,
     ):
         """
         Create a presentation exchange record for input presentation request.
@@ -187,6 +190,7 @@ class PresentationManager:
             state=V10PresentationExchange.STATE_REQUEST_SENT,
             presentation_request=presentation_request_message.indy_proof_request(),
             presentation_request_dict=presentation_request_message,
+            auto_verify=auto_verify,
             trace=(presentation_request_message._trace is not None),
         )
         async with self._profile.session() as session:

--- a/aries_cloudagent/protocols/present_proof/v1_0/models/presentation_exchange.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/models/presentation_exchange.py
@@ -301,8 +301,7 @@ class V10PresentationExchangeSchema(BaseExchangeSchema):
         example=False,
     )
     auto_verify = fields.Bool(
-        required=False,
-        description="Verifier choice to auto-verify proof presentation"
+        required=False, description="Verifier choice to auto-verify proof presentation"
     )
     error_msg = fields.Str(
         required=False, description="Error message", example="Invalid structure"

--- a/aries_cloudagent/protocols/present_proof/v1_0/models/presentation_exchange.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/models/presentation_exchange.py
@@ -75,6 +75,7 @@ class V10PresentationExchange(BaseExchangeRecord):
         presentation: Union[IndyProof, Mapping] = None,  # indy proof
         verified: str = None,
         auto_present: bool = False,
+        auto_verify: bool = False,
         error_msg: str = None,
         trace: bool = False,  # backward compat: BaseRecord.from_storage()
         **kwargs,
@@ -96,6 +97,7 @@ class V10PresentationExchange(BaseExchangeRecord):
         self._presentation = IndyProof.serde(presentation)
         self.verified = verified
         self.auto_present = auto_present
+        self.auto_verify = auto_verify
         self.error_msg = error_msg
 
     @property
@@ -203,6 +205,7 @@ class V10PresentationExchange(BaseExchangeRecord):
                     "role",
                     "state",
                     "auto_present",
+                    "auto_verify",
                     "error_msg",
                     "verified",
                     "trace",
@@ -296,6 +299,10 @@ class V10PresentationExchangeSchema(BaseExchangeSchema):
         required=False,
         description="Prover choice to auto-present proof as verifier requests",
         example=False,
+    )
+    auto_verify = fields.Bool(
+        required=False,
+        description="Verifier choice to auto-verify proof presentation"
     )
     error_msg = fields.Str(
         required=False, description="Error message", example="Invalid structure"

--- a/aries_cloudagent/protocols/present_proof/v1_0/models/tests/test_record.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/models/tests/test_record.py
@@ -110,6 +110,7 @@ class TestRecord(AsyncTestCase):
             "role": None,
             "state": None,
             "auto_present": True,
+            "auto_verify": False,
             "error_msg": None,
             "verified": None,
             "trace": False,

--- a/aries_cloudagent/protocols/present_proof/v1_0/routes.py
+++ b/aries_cloudagent/protocols/present_proof/v1_0/routes.py
@@ -133,7 +133,7 @@ class V10PresentationCreateRequestRequestSchema(AdminAPIMessageTracingSchema):
     auto_verify = fields.Bool(
         description="Verifier choice to auto-verify proof presentation",
         required=False,
-        example=False
+        example=False,
     )
     trace = fields.Bool(
         description="Whether to trace event (default false)",
@@ -151,18 +151,21 @@ class V10PresentationSendRequestRequestSchema(
         description="Connection identifier", required=True, example=UUIDFour.EXAMPLE
     )
 
+
 class V10PresentationSendRequestToProposalSchema(AdminAPIMessageTracingSchema):
-    """Request schema for sending a proof request bound to a proposal"""
+    """Request schema for sending a proof request bound to a proposal."""
+
     auto_verify = fields.Bool(
         description="Verifier choice to auto-verify proof presentation",
         required=False,
-        example=False
+        example=False,
     )
     trace = fields.Bool(
         description="Whether to trace event (default false)",
         required=False,
         example=False,
     )
+
 
 class CredentialsFetchQueryStringSchema(OpenAPISchema):
     """Parameters and validators for credentials fetch request query string."""
@@ -507,7 +510,7 @@ async def presentation_exchange_create_request(request: web.BaseRequest):
         pres_ex_record = await presentation_manager.create_exchange_for_request(
             connection_id=None,
             presentation_request_message=presentation_request_message,
-            auto_verify=auto_verify
+            auto_verify=auto_verify,
         )
         result = pres_ex_record.serialize()
     except (BaseModelError, StorageError) as err:
@@ -593,7 +596,7 @@ async def presentation_exchange_send_free_request(request: web.BaseRequest):
         pres_ex_record = await presentation_manager.create_exchange_for_request(
             connection_id=connection_id,
             presentation_request_message=presentation_request_message,
-            auto_verify=auto_verify
+            auto_verify=auto_verify,
         )
         result = pres_ex_record.serialize()
     except (BaseModelError, StorageError) as err:

--- a/aries_cloudagent/protocols/present_proof/v2_0/formats/dif/handler.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/formats/dif/handler.py
@@ -160,6 +160,8 @@ class DIFPresFormatHandler(V20PresFormatHandler):
         else:
             dif_proof_request["options"] = pres_proposal_dict["options"]
             del pres_proposal_dict["options"]
+            if "challenge" not in dif_proof_request.get("options"):
+                dif_proof_request["options"]["challenge"] = str(uuid4())
         dif_proof_request["presentation_definition"] = pres_proposal_dict
 
         return self.get_format_data(PRES_20_REQUEST, dif_proof_request)

--- a/aries_cloudagent/protocols/present_proof/v2_0/formats/dif/handler.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/formats/dif/handler.py
@@ -151,9 +151,16 @@ class DIFPresFormatHandler(V20PresFormatHandler):
             A tuple (updated presentation exchange record, presentation request message)
 
         """
-        dif_proof_request = pres_ex_record.pres_proposal.attachment(
+        dif_proof_request = {}
+        pres_proposal_dict = pres_ex_record.pres_proposal.attachment(
             DIFPresFormatHandler.format
         )
+        if "options" not in pres_proposal_dict:
+            dif_proof_request["options"] = {"challenge": str(uuid4())}
+        else:
+            dif_proof_request["options"] = pres_proposal_dict["options"]
+            del pres_proposal_dict["options"]
+        dif_proof_request["presentation_definition"] = pres_proposal_dict
 
         return self.get_format_data(PRES_20_REQUEST, dif_proof_request)
 

--- a/aries_cloudagent/protocols/present_proof/v2_0/formats/dif/tests/test_handler.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/formats/dif/tests/test_handler.py
@@ -341,9 +341,7 @@ class TestDIFFormatHandler(AsyncTestCase):
 
     async def test_create_bound_request_b(self):
         dif_proposal_dict = {
-            "options": {
-                "challenge": "test123"
-            },
+            "options": {"challenge": "test123"},
             "input_descriptors": [
                 {
                     "id": "citizenship_input_1",
@@ -365,7 +363,7 @@ class TestDIFFormatHandler(AsyncTestCase):
                         ],
                     },
                 }
-            ]
+            ],
         }
         dif_pres_proposal = V20PresProposal(
             formats=[

--- a/aries_cloudagent/protocols/present_proof/v2_0/formats/dif/tests/test_handler.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/formats/dif/tests/test_handler.py
@@ -284,8 +284,66 @@ class TestDIFFormatHandler(AsyncTestCase):
         for suite in suites:
             assert type(suite) in types
 
-    async def test_create_bound_request(self):
+    async def test_create_bound_request_a(self):
         dif_proposal_dict = {
+            "input_descriptors": [
+                {
+                    "id": "citizenship_input_1",
+                    "name": "EU Driver's License",
+                    "group": ["A"],
+                    "schema": [
+                        {
+                            "uri": "https://www.w3.org/2018/credentials#VerifiableCredential"
+                        }
+                    ],
+                    "constraints": {
+                        "limit_disclosure": "required",
+                        "fields": [
+                            {
+                                "path": ["$.credentialSubject.givenName"],
+                                "purpose": "The claim must be from one of the specified issuers",
+                                "filter": {"type": "string", "enum": ["JOHN", "CAI"]},
+                            }
+                        ],
+                    },
+                }
+            ]
+        }
+        dif_pres_proposal = V20PresProposal(
+            formats=[
+                V20PresFormat(
+                    attach_id="dif",
+                    format_=ATTACHMENT_FORMAT[PRES_20_PROPOSAL][
+                        V20PresFormat.Format.DIF.api
+                    ],
+                )
+            ],
+            proposals_attach=[
+                AttachDecorator.data_json(dif_proposal_dict, ident="dif")
+            ],
+        )
+        record = V20PresExRecord(
+            pres_ex_id="pxid",
+            thread_id="thid",
+            connection_id="conn_id",
+            initiator="init",
+            role="role",
+            state="state",
+            pres_proposal=dif_pres_proposal,
+            verified="false",
+            auto_present=True,
+            error_msg="error",
+        )
+        output = await self.handler.create_bound_request(pres_ex_record=record)
+        assert isinstance(output[0], V20PresFormat) and isinstance(
+            output[1], AttachDecorator
+        )
+
+    async def test_create_bound_request_b(self):
+        dif_proposal_dict = {
+            "options": {
+                "challenge": "test123"
+            },
             "input_descriptors": [
                 {
                     "id": "citizenship_input_1",

--- a/aries_cloudagent/protocols/present_proof/v2_0/formats/dif/tests/test_handler.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/formats/dif/tests/test_handler.py
@@ -395,6 +395,62 @@ class TestDIFFormatHandler(AsyncTestCase):
             output[1], AttachDecorator
         )
 
+    async def test_create_bound_request_c(self):
+        dif_proposal_dict = {
+            "options": {"domain": "test123"},
+            "input_descriptors": [
+                {
+                    "id": "citizenship_input_1",
+                    "name": "EU Driver's License",
+                    "group": ["A"],
+                    "schema": [
+                        {
+                            "uri": "https://www.w3.org/2018/credentials#VerifiableCredential"
+                        }
+                    ],
+                    "constraints": {
+                        "limit_disclosure": "required",
+                        "fields": [
+                            {
+                                "path": ["$.credentialSubject.givenName"],
+                                "purpose": "The claim must be from one of the specified issuers",
+                                "filter": {"type": "string", "enum": ["JOHN", "CAI"]},
+                            }
+                        ],
+                    },
+                }
+            ],
+        }
+        dif_pres_proposal = V20PresProposal(
+            formats=[
+                V20PresFormat(
+                    attach_id="dif",
+                    format_=ATTACHMENT_FORMAT[PRES_20_PROPOSAL][
+                        V20PresFormat.Format.DIF.api
+                    ],
+                )
+            ],
+            proposals_attach=[
+                AttachDecorator.data_json(dif_proposal_dict, ident="dif")
+            ],
+        )
+        record = V20PresExRecord(
+            pres_ex_id="pxid",
+            thread_id="thid",
+            connection_id="conn_id",
+            initiator="init",
+            role="role",
+            state="state",
+            pres_proposal=dif_pres_proposal,
+            verified="false",
+            auto_present=True,
+            error_msg="error",
+        )
+        output = await self.handler.create_bound_request(pres_ex_record=record)
+        assert isinstance(output[0], V20PresFormat) and isinstance(
+            output[1], AttachDecorator
+        )
+
     async def test_create_pres(self):
         dif_pres_request = V20PresRequest(
             formats=[

--- a/aries_cloudagent/protocols/present_proof/v2_0/handlers/pres_handler.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/handlers/pres_handler.py
@@ -49,7 +49,7 @@ class V20PresHandler(BaseHandler):
         )
 
         # Automatically move to next state if flag is set
-        if context.settings.get("debug.auto_verify_presentation"):
+        if pres_ex_record and pres_ex_record.auto_verify:
             try:
                 await pres_manager.verify_pres(pres_ex_record)
             except (BaseModelError, LedgerError, StorageError) as err:

--- a/aries_cloudagent/protocols/present_proof/v2_0/manager.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/manager.py
@@ -161,7 +161,10 @@ class V20PresManager:
         return pres_ex_record, pres_request_message
 
     async def create_exchange_for_request(
-        self, connection_id: str, pres_request_message: V20PresRequest
+        self,
+        connection_id: str,
+        pres_request_message: V20PresRequest,
+        auto_verify: bool = None,
     ):
         """
         Create a presentation exchange record for input presentation request.
@@ -182,6 +185,7 @@ class V20PresManager:
             role=V20PresExRecord.ROLE_VERIFIER,
             state=V20PresExRecord.STATE_REQUEST_SENT,
             pres_request=pres_request_message,
+            auto_verify=auto_verify,
             trace=(pres_request_message._trace is not None),
         )
         async with self._profile.session() as session:

--- a/aries_cloudagent/protocols/present_proof/v2_0/models/pres_exchange.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/models/pres_exchange.py
@@ -63,6 +63,7 @@ class V20PresExRecord(BaseExchangeRecord):
         pres: Union[V20Pres, Mapping] = None,  # aries message
         verified: str = None,
         auto_present: bool = False,
+        auto_verify: bool = False,
         error_msg: str = None,
         trace: bool = False,  # backward compat: BaseRecord.FromStorage()
         by_format: Mapping = None,  # backward compat: BaseRecord.FromStorage()
@@ -190,6 +191,7 @@ class V20PresExRecord(BaseExchangeRecord):
                     "state",
                     "verified",
                     "auto_present",
+                    "auto_verify",
                     "error_msg",
                     "trace",
                 )
@@ -308,6 +310,9 @@ class V20PresExRecordSchema(BaseExchangeSchema):
         required=False,
         description="Prover choice to auto-present proof as verifier requests",
         example=False,
+    )
+    auto_verify = fields.Bool(
+        required=False, description="Verifier choice to auto-verify proof presentation"
     )
     error_msg = fields.Str(
         required=False, description="Error message", example="Invalid structure"

--- a/aries_cloudagent/protocols/present_proof/v2_0/models/pres_exchange.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/models/pres_exchange.py
@@ -81,6 +81,7 @@ class V20PresExRecord(BaseExchangeRecord):
         self._pres = V20Pres.serde(pres)
         self.verified = verified
         self.auto_present = auto_present
+        self.auto_verify = auto_verify
         self.error_msg = error_msg
 
     @property

--- a/aries_cloudagent/protocols/present_proof/v2_0/models/tests/test_record.py
+++ b/aries_cloudagent/protocols/present_proof/v2_0/models/tests/test_record.py
@@ -111,6 +111,7 @@ class TestRecord(AsyncTestCase):
             "pres_proposal": pres_proposal.serialize(),
             "verified": "false",
             "auto_present": True,
+            "auto_verify": False,
             "error_msg": "error",
             "trace": False,
         }

--- a/requirements.bbs.txt
+++ b/requirements.bbs.txt
@@ -1,1 +1,1 @@
-ursa-bbs-signatures~=1.0.1
+ursa-bbs-signatures==1.0.1


### PR DESCRIPTION
- `upgrade` command was recently implemented to handle such situations [live agents with persistent wallets]. This will find and update the existing `V20PresExRecords` which were affected by the issue.
- DO NOT RUN this on production yet, if you want to proceed with this approach then let me know and I can do some additional testing on my end.

upgrade logic implemented here: `aries_cloudagent/commands/upgrade.py -> update_existing_records`